### PR TITLE
Update classifier names to comply with pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     classifiers=[
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "License :: OSI Approved :: Apache-2.0",
+        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
- Update classifier for Apache license to `License :: OSI Approved :: Apache Software License`
- List of supported classifiers https://pypi.org/pypi?%3Aaction=list_classifiers

Currently this blocks deployment of package to pypi (Test on pypitest)

```
twine upload --repository $REGISTRY $PACKAGE

Deploying package /tmp/workspace/chainlibpy-1.0.0.tar.gz to testpypi
Uploading distributions to https://test.pypi.org/legacy/
Uploading chainlibpy-1.0.0.tar.gz
100% 16.2k/16.2k [00:00<00:00, 94.7kB/s]
NOTE: Try --verbose to see response content.
HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
Invalid value for classifiers. Error: Classifier 'License :: OSI Approved :: Apache-2.0' is not a valid classifier.
```